### PR TITLE
bug fixed, get tour preference by touristId instead of Id, test changed accordingly

### DIFF
--- a/src/Explorer.API/Controllers/Tourist/TourPreferenceController.cs
+++ b/src/Explorer.API/Controllers/Tourist/TourPreferenceController.cs
@@ -1,8 +1,12 @@
-﻿using Explorer.Tours.API.Dtos;
+﻿using Explorer.BuildingBlocks.Core.UseCases;
+using Explorer.Stakeholders.Infrastructure.Authentication;
+using Explorer.Tours.API.Dtos;
 using Explorer.Tours.API.Public.Tourist;
 using Explorer.Tours.Core.UseCases.Tourist;
+using FluentResults;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Explorer.Tours.API.Public.Administration;
 
 namespace Explorer.API.Controllers.Tourist
 {
@@ -17,10 +21,10 @@ namespace Explorer.API.Controllers.Tourist
         }
 
         [HttpGet]
-        public ActionResult<TourPreferenceDto> GetByTouristId(long id)
+        public ActionResult<PagedResult<TourPreferenceDto>> GetByTouristId()
         {
-            var result = _tourPreferenceService.GetByTouristId(id);
-            return CreateResponse(result);
+            var allTourPreferences = _tourPreferenceService.GetByTouristId(User.PersonId());
+            return CreateResponse(allTourPreferences.ToResult());
         }
 
         [HttpPost]

--- a/src/Modules/Tours/Explorer.Tours.API/Public/Tourist/ITourPreferenceService.cs
+++ b/src/Modules/Tours/Explorer.Tours.API/Public/Tourist/ITourPreferenceService.cs
@@ -12,6 +12,6 @@ namespace Explorer.Tours.API.Public.Tourist
     public interface ITourPreferenceService
     {
         Result<TourPreferenceDto> Create(TourPreferenceDto equipment);
-        Result<TourPreferenceDto> GetByTouristId(long touristId);   
+        PagedResult<TourPreferenceDto> GetByTouristId(long touristId);   
     }
 }

--- a/src/Modules/Tours/Explorer.Tours.Core/UseCases/Tourist/TourPreferenceService.cs
+++ b/src/Modules/Tours/Explorer.Tours.Core/UseCases/Tourist/TourPreferenceService.cs
@@ -1,8 +1,10 @@
 ﻿using AutoMapper;
 using Explorer.BuildingBlocks.Core.UseCases;
+using Explorer.Stakeholders.Core.Domain;
 using Explorer.Tours.API.Dtos;
 using Explorer.Tours.API.Public.Tourist;
 using Explorer.Tours.Core.Domain;
+using Explorer.Tours.Core.Domain.RepositoryInterfaces;
 using FluentResults;
 using System;
 using System.Collections.Generic;
@@ -21,10 +23,17 @@ namespace Explorer.Tours.Core.UseCases.Tourist
             _repository = repository;
         }
 
-        public Result<TourPreferenceDto> GetByTouristId(long touristId)
+        public PagedResult<TourPreferenceDto> GetByTouristId(long userId)
         {
-            var tourPreference = _repository.Get(touristId);
-            return MapToDto(tourPreference);
+            var allTourPreferences = _repository.GetPaged(1, int.MaxValue);
+
+
+            var filteredTourPreferences = allTourPreferences.Results
+                               .Where(tp => tp.TouristId == userId)
+                               .Select(tp => MapToDto(tp))
+                               .ToList();
+
+            return new PagedResult<TourPreferenceDto>(filteredTourPreferences, filteredTourPreferences.Count());
         }
     }
 }

--- a/src/Modules/Tours/Explorer.Tours.Tests/Integration/Tour/GetTourPreferenceTests.cs
+++ b/src/Modules/Tours/Explorer.Tours.Tests/Integration/Tour/GetTourPreferenceTests.cs
@@ -1,12 +1,17 @@
 ﻿using Explorer.API.Controllers;
 using Explorer.API.Controllers.Tourist;
+using Explorer.BuildingBlocks.Core.UseCases;
+using Explorer.Stakeholders.Core.Domain;
 using Explorer.Tours.API.Dtos;
 using Explorer.Tours.API.Public.Tourist;
 using Explorer.Tours.Core.Domain;
 using Explorer.Tours.Infrastructure.Database;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
+using System.Security.Claims;
+
 
 namespace Explorer.Tours.Tests.Integration.Tour
 {
@@ -21,17 +26,30 @@ namespace Explorer.Tours.Tests.Integration.Tour
             using var scope = Factory.Services.CreateScope();
             var controller = CreateController(scope);
             var dbContext = scope.ServiceProvider.GetRequiredService<ToursContext>();
-            long id = -1; 
             
-            var result = ((ObjectResult)controller.GetByTouristId(id).Result)?.Value as TourPreferenceDto;
+            var result = ((ObjectResult)controller.GetByTouristId().Result)?.Value as PagedResult<TourPreferenceDto>;
 
             result.ShouldNotBeNull();
-            result.Id.ShouldBe(id);
+            result.Results.First().Id.ShouldBe(-1);
         }
 
         private static TourPreferenceController CreateController(IServiceScope scope)
         {
-            return new TourPreferenceController(scope.ServiceProvider.GetRequiredService<ITourPreferenceService>());
+            return new TourPreferenceController(scope.ServiceProvider.GetRequiredService<ITourPreferenceService>())
+            {
+                ControllerContext = new ControllerContext
+                {
+                    HttpContext = new DefaultHttpContext
+                    {
+                        User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+                        {
+                    new Claim("personId", "-21"),
+                    new Claim("id", "-21")
+                }))
+                    }
+                }
+            };
         }
+
     }
 }


### PR DESCRIPTION
User ID Access Fix: Implemented proper access to the user ID via ClaimsPrincipal, ensuring accurate UserId retrieval for the user accessing tour preferences.

Refactored Tour Preference Retrieval Method: Modified the method to ensure that tour preferences are retrieved and returned correctly in the form of a PagedResult object.

Testing: Added and updated integration tests to verify that tour preference retrieval functions correctly with the new user ID access approach. The tests now validate that the results are accurate and that the ID matches the expected values.