### PR TITLE
feat: conditions for tour review

### DIFF
--- a/src/Explorer.API/Controllers/Tourist/TourReviewController.cs
+++ b/src/Explorer.API/Controllers/Tourist/TourReviewController.cs
@@ -45,8 +45,8 @@ namespace Explorer.API.Controllers.Tourist
         [HttpPut("update/review")]
         public ActionResult<PagedResult<TourReviewDto>> UpdateReview([FromBody] TourReviewDto review)
         {
-            var result = _tourReviewService.Update(review);
-            return CreateResponse(result);
+            var reslt = _tourReviewService.Update(review);
+            return CreateResponse(reslt);
         }
 
 

--- a/src/Modules/Tours/Explorer.Tours.Core/Domain/TourExecution.cs
+++ b/src/Modules/Tours/Explorer.Tours.Core/Domain/TourExecution.cs
@@ -31,7 +31,7 @@ namespace Explorer.Tours.Core.Domain
 
         public double GetProgress()
         {
-            return TourExecutionCheckpoints.Where(c => c.ArrivalAt != null).Count() / TourExecutionCheckpoints.Count();
+            return TourExecutionCheckpoints.Where(c => c.ArrivalAt != null).Count() / (double)TourExecutionCheckpoints.Count();
         }
 
         public bool IsLastActivityOlderThanSevenDays()

--- a/src/Modules/Tours/Explorer.Tours.Infrastructure/Database/Repositories/TourExecutionRepository.cs
+++ b/src/Modules/Tours/Explorer.Tours.Infrastructure/Database/Repositories/TourExecutionRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Explorer.BuildingBlocks.Core.Domain;
+using Explorer.BuildingBlocks.Core.Domain.Enums;
 using Explorer.BuildingBlocks.Core.UseCases;
 using Explorer.BuildingBlocks.Infrastructure.Database;
 using Explorer.Tours.Core.Domain;
@@ -50,7 +51,7 @@ namespace Explorer.Tours.Infrastructure.Database.Repositories
 
         public TourExecution GetByUserId(int userId)
         {
-            return _dbContext.TourExecutions.Where(t=> t.UserId == userId).FirstOrDefault();
+            return _dbContext.TourExecutions.Where(t => t.UserId == userId && t.Status == TourExecutionStatus.InProgress).FirstOrDefault();
         }
     }
 }

--- a/src/Modules/Tours/Explorer.Tours.Tests/Integration/Tour/TourReviewTests.cs
+++ b/src/Modules/Tours/Explorer.Tours.Tests/Integration/Tour/TourReviewTests.cs
@@ -4,6 +4,7 @@ using Explorer.BuildingBlocks.Core.UseCases;
 using Explorer.Stakeholders.API.Dtos;
 using Explorer.Tours.API.Dtos;
 using Explorer.Tours.API.Public.Administration;
+using Explorer.Tours.Core.Domain;
 using Explorer.Tours.Infrastructure.Database;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -144,7 +145,42 @@ namespace Explorer.Tours.Tests.Integration.Tour
             result.Results.Count.ShouldBe(2);
             result.TotalCount.ShouldBe(2);
         }
+        [Fact]
+        public void Update_successful()
+        {
+            // Arrange
+            using var scope = Factory.Services.CreateScope();
+            var controller = CreateController(scope, "-1");
+            var dbContext = scope.ServiceProvider.GetRequiredService<ToursContext>();
 
+            var updatedReviewDto = new TourReviewDto
+            {
+                UserId = -1,
+                TourId = -1,
+                Grade = 5,
+                Comment = "Updated Comment",
+                Image = new TourImageDto
+                {
+                    Data = "updated data",
+                    UploadedAt = DateTime.UtcNow,
+                    MimeType = "image/png"
+                },
+                ReviewDate = DateTime.UtcNow,
+                VisitDate = DateTime.UtcNow.AddDays(-5),
+                Progress = 100
+            };
+
+            //Act
+            var result = ((ObjectResult)controller.UpdateReview(updatedReviewDto).Result)?.Value as TourReviewDto;
+
+            //Assert - Response
+            //result.Id.ShouldBe(-1);
+
+            //Assert - Database
+
+            result.ShouldNotBeNull();
+            //storedEntity.Id.ShouldBe(result.Id);
+        }
         private static TourReviewController CreateController(IServiceScope scope, string number)
         {
             return new TourReviewController(scope.ServiceProvider.GetRequiredService<ITourReviewService>(), scope.ServiceProvider.GetRequiredService<ITourService>())


### PR DESCRIPTION
### Change goals
As a tourist,
I want to be able to leave or update a review for a tour I have attended at least 35%, not more than 7 days ago,
So that I can share my feedback and help future tourists decide if they want to take the tour and so that I can rate the tour accurately based on my personal experience while it’s still fresh in my mind.

### Acceptance criteria:
- New attribute for tour progres in Tour Review entity
- New Button for editing and edit form

### DataBase Changes
- New column in tourReview table added for attribute progress